### PR TITLE
Fixed CPU usage indicator on Linux

### DIFF
--- a/src/utilities.h
+++ b/src/utilities.h
@@ -23,6 +23,10 @@
 #ifndef _QDS_UTILITIES_H
 #define _QDS_UTILITIES_H
 
+#include <stdint.h>
+
+#include <utility>
+
 #include <QProcess>
 
 class Utilities : public QObject {
@@ -47,6 +51,9 @@ class Utilities : public QObject {
     void readConnectedToACProcess (int exit_code = 0);
 
   private:
+    std::pair<uint64_t, uint64_t> getCpuJiffies();
+    std::pair<uint64_t, uint64_t> m_pastCpuJiffies{0, 0};
+
     int m_cpuUsage;
     int m_batteryLevel;
     bool m_connectedToAC;


### PR DESCRIPTION
The previous implementation was only using one sample from /proc/stat to compute the current CPU usage. That gave the average CPU usage since system start. The correct way is to use the difference between two samples. This patch does so without needing to spawn a bash process.