### PR TITLE
Fixed Linux CPU usage GUI update

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -214,6 +214,7 @@ void Utilities::updateCpuUsage()
                  (cpuJiffies.second - m_pastCpuJiffies.second);
 
     m_pastCpuJiffies = cpuJiffies;
+    emit cpuUsageChanged();
 #endif
 
     QTimer::singleShot (1000,


### PR DESCRIPTION
The Linux version of Utilities::updateCpuUsage() wasn't emitting the
cpuUsageChanged() signal after recalculating the CPU usage. This caused the GUI
to only update the CPU usage once on application startup.