### PR TITLE
Port QDriverStation to Qt 6.10.0

### DIFF
--- a/qml/Dialogs/VirtualJoystickWindow.qml
+++ b/qml/Dialogs/VirtualJoystickWindow.qml
@@ -149,8 +149,8 @@ Window {
         Spinbox {
             id: spin
             value: 100
-            minimumValue: 0
-            maximumValue: 100
+            from: 0
+            to: 100
             Layout.fillWidth: true
             onValueChanged: QJoysticks.setVirtualJoystickRange (value / 100)
         }

--- a/qml/MainWindow/BatteryChart.qml
+++ b/qml/MainWindow/BatteryChart.qml
@@ -1,6 +1,4 @@
 import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Styles 1.0
 
 import "../Globals.js" as Globals
 

--- a/qml/MainWindow/Charts.qml
+++ b/qml/MainWindow/Charts.qml
@@ -147,8 +147,8 @@ Item {
         Plot {
             id: loss
             value: 0
-            minimumValue: 0
-            maximumValue: 100
+            from: 0
+            to: 100
             Layout.fillWidth: true
             Layout.fillHeight: true
             barColor: Globals.Colors.PacketLoss

--- a/qml/MainWindow/Joysticks.qml
+++ b/qml/MainWindow/Joysticks.qml
@@ -276,8 +276,8 @@ Item {
                     id: axes
                     delegate: Progressbar {
                         id: progressbar
-                        minimumValue: 0
-                        maximumValue: 200
+                        from: 0
+                        to: 200
                         width: Globals.scale (54)
                         text: qsTr ("Axis") + " " + index
                         height: getWidgetHeight (axes.model)
@@ -345,8 +345,8 @@ Item {
                     //
                     delegate: Progressbar {
                         id: button
-                        minimumValue: 0
-                        maximumValue: 1
+                        from: 0
+                        to: 1
 
                         text: index
                         width: Globals.scale (28)
@@ -397,8 +397,8 @@ Item {
                     delegate: Spinbox {
                         id: spinbox
                         enabled: false
-                        minimumValue: 0
-                        maximumValue: 360
+                        from: 0
+                        to: 360
                         width: Globals.scale (64)
 
                         Connections {

--- a/qml/MainWindow/MainWindow.qml
+++ b/qml/MainWindow/MainWindow.qml
@@ -23,7 +23,7 @@
 import QtQuick 2.0
 import QtQuick.Window 2.0
 import QtQuick.Layouts 1.0
-import QtQuick.Controls 1.0
+import QtQuick.Controls 2.15
 import Qt.labs.settings 1.0
 
 import "../Globals.js" as Globals

--- a/qml/MainWindow/Messages.qml
+++ b/qml/MainWindow/Messages.qml
@@ -22,7 +22,7 @@
 
 import QtQuick 2.0
 import QtQuick.Layouts 1.0
-import QtQuick.Controls 1.4
+import QtQuick.Controls 2.15
 import Qt.labs.settings 1.0
 
 import "../Widgets"

--- a/qml/MainWindow/Preferences.qml
+++ b/qml/MainWindow/Preferences.qml
@@ -68,8 +68,8 @@ RowLayout {
         //
         Spinbox {
             id: teamNumber
-            minimumValue: 0
-            maximumValue: 9999
+            from: 0
+            to: 9999
             Layout.fillWidth: true
             value: CppDS.teamNumber
             onValueChanged: CppDS.teamNumber = value
@@ -161,8 +161,8 @@ RowLayout {
             Spinbox {
                 value: 5
                 id: countdown
-                minimumValue: 0
-                maximumValue: 150
+                from: 0
+                to: 150
                 Layout.minimumWidth: Globals.scale (36)
             }
 
@@ -177,8 +177,8 @@ RowLayout {
             Spinbox {
                 value: 15
                 id: autonomous
-                minimumValue: 0
-                maximumValue: 150
+                from: 0
+                to: 150
                 Layout.minimumWidth: Globals.scale (36)
             }
 
@@ -193,8 +193,8 @@ RowLayout {
             Spinbox {
                 value: 1
                 id: delay
-                minimumValue: 0
-                maximumValue: 150
+                from: 0
+                to: 150
                 Layout.minimumWidth: Globals.scale (36)
             }
 
@@ -209,8 +209,8 @@ RowLayout {
             Spinbox {
                 value: 100
                 id: teleop
-                minimumValue: 0
-                maximumValue: 150
+                from: 0
+                to: 150
                 Layout.minimumWidth: Globals.scale (36)
             }
 
@@ -225,8 +225,8 @@ RowLayout {
             Spinbox {
                 value: 20
                 id: endGame
-                minimumValue: 0
-                maximumValue: 150
+                from: 0
+                to: 150
                 Layout.minimumWidth: Globals.scale (36)
             }
         }

--- a/qml/MainWindow/VoltageGraph.qml
+++ b/qml/MainWindow/VoltageGraph.qml
@@ -39,7 +39,7 @@ Plot {
 
         if (!CppDS.connectedToRobot) {
             barColor = noCommsColor
-            value = maximumValue * 0.95
+            value = to * 0.95
         }
 
         else if (getLevel() > 0.80)
@@ -59,7 +59,7 @@ Plot {
     //
     // Start graphing from origin, not from the middle or some other place
     //
-    minimumValue: 0
+    from: 0
     Component.onCompleted: update()
-    maximumValue: CppDS.maximumBatteryVoltage
+    to: CppDS.maximumBatteryVoltage
 }

--- a/qml/Widgets/Combobox.qml
+++ b/qml/Widgets/Combobox.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Styles 1.0
+import QtQuick.Controls 2.15
 
 import "../Globals.js" as Globals
 
@@ -13,42 +12,35 @@ ComboBox {
     property bool alignRight: false
 
     //
-    // We can do a combo-box from scratch, but I'm lazy
+    // Qt 6 ComboBox with simplified styling
     //
-    style: ComboBoxStyle {
-        background: Rectangle {
-            border.width: Globals.scale (1)
-            color: Globals.Colors.WidgetBackground
-            border.color: Globals.Colors.WidgetBorder
+    background: Rectangle {
+        border.width: Globals.scale (1)
+        color: Globals.Colors.WidgetBackground
+        border.color: Globals.Colors.WidgetBorder
 
-            Icon {
-                size: Globals.scale (12)
-                name: icons.fa_chevron_down
-
-                anchors {
-                    right: parent.right
-                    margins: Globals.spacing
-                    verticalCenter: parent.verticalCenter
-                }
-            }
-        }
-
-        label: Text {
-            id: _label
-            smooth: true
-            text: control.currentText
-            font.family: Globals.uiFont
-            color: Globals.Colors.Foreground
-            font.pixelSize: Globals.scale (12)
-            verticalAlignment: Text.AlignVCenter
-            horizontalAlignment: alignRight ? Text.AlignRight : Text.AlignLeft
+        Icon {
+            size: Globals.scale (12)
+            name: icons.fa_chevron_down
 
             anchors {
+                right: parent.right
+                margins: Globals.spacing
                 verticalCenter: parent.verticalCenter
-                left: alignRight ? undefined: parent.left
-                right: alignRight ? parent.right : undefined
-                margins: alignRight ? Globals.spacing + Globals.scale(12) : 0
             }
         }
+    }
+
+    contentItem: Text {
+        leftPadding: alignRight ? 0 : Globals.spacing
+        rightPadding: alignRight ? Globals.spacing + Globals.scale(12) : 0
+        smooth: true
+        text: combo.displayText
+        font.family: Globals.uiFont
+        color: Globals.Colors.Foreground
+        font.pixelSize: Globals.scale (12)
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: alignRight ? Text.AlignRight : Text.AlignLeft
+        elide: Text.ElideRight
     }
 }

--- a/qml/Widgets/Plot.qml
+++ b/qml/Widgets/Plot.qml
@@ -50,8 +50,8 @@ Rectangle {
     // Display options
     //
     property double value: 0
-    property double minimumValue: 0
-    property double maximumValue: 100
+    property double from: 0
+    property double to: 100
 
     //
     // Emitted when the timer expires and a canvas repaint is done
@@ -62,7 +62,7 @@ Rectangle {
     // Calculates the ratio between the current value and the maxinum value
     //
     function getLevel() {
-        return Math.max (value / maximumValue, minimumValue / maximumValue)
+        return Math.max (value / to, from / to)
     }
 
     //

--- a/qml/Widgets/Progressbar.qml
+++ b/qml/Widgets/Progressbar.qml
@@ -32,8 +32,8 @@ Rectangle {
     //
     // The values hold the 'range' of the progressbar
     //
-    property int minimumValue: 0
-    property int maximumValue: 100
+    property int from: 0
+    property int to: 100
 
     //
     // Default caption will display current relative value of progressbar
@@ -78,7 +78,7 @@ Rectangle {
         height: parent.height
         border.width: parent.border.width
         border.color: parent.border.color
-        width: parent.width * ((minimumValue + value) / maximumValue)
+        width: parent.width * ((from + value) / to)
     }
 
     //

--- a/qml/Widgets/Spinbox.qml
+++ b/qml/Widgets/Spinbox.qml
@@ -21,35 +21,30 @@
  */
 
 import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Styles 1.4
+import QtQuick.Controls 2.15
 
 import "../Globals.js" as Globals
 
 SpinBox {
-    width: Globals.scale (64)
-    height: Globals.scale (24)
+    editable: true
+    implicitWidth: Globals.scale (64)
+    implicitHeight: Globals.scale (24)
 
-    //
-    // Assign a custom style to the control
-    //
-    style: SpinBoxStyle {
-        background: Rectangle {
-            implicitWidth: parent.width
-            implicitHeight: parent.height
-            border.width: Globals.scale (1)
-            opacity: control.enabled ? 1 : 0.5
-            color: Globals.Colors.TextAreaBackground
-            border.color: Globals.Colors.WidgetBorder
+    // Qt 6 SpinBox doesn't support custom styling in the same way
+    // Basic styling through properties
 
-            Behavior on opacity {
-                NumberAnimation {
-                    duration: Globals.slowAnimation
-                }
+    background: Rectangle {
+        implicitWidth: parent.width
+        implicitHeight: parent.height
+        border.width: Globals.scale (1)
+        opacity: parent.enabled ? 1 : 0.5
+        color: Globals.Colors.TextAreaBackground
+        border.color: Globals.Colors.WidgetBorder
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: Globals.slowAnimation
             }
         }
-
-        textColor: Globals.Colors.TextAreaForeground
-        selectionColor: Globals.Colors.HighlightColor
     }
 }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -196,7 +196,7 @@ void Utilities::updateCpuUsage()
    emit cpuUsageChanged();
 #elif defined Q_OS_MAC
    m_cpuProcess.terminate();
-   m_cpuProcess.start(CPU_CMD, QIODevice::ReadOnly);
+   m_cpuProcess.startCommand(CPU_CMD, QIODevice::ReadOnly);
 #elif defined Q_OS_LINUX
    auto cpuJiffies = getCpuJiffies();
 
@@ -220,7 +220,7 @@ void Utilities::updateBatteryLevel()
    emit batteryLevelChanged();
 #else
    m_batteryLevelProcess.terminate();
-   m_batteryLevelProcess.start(BTY_CMD, QIODevice::ReadOnly);
+   m_batteryLevelProcess.startCommand(BTY_CMD, QIODevice::ReadOnly);
 #endif
 
    QTimer::singleShot(1000, Qt::PreciseTimer, this, SLOT(updateBatteryLevel()));
@@ -237,7 +237,7 @@ void Utilities::updateConnectedToAC()
    emit connectedToACChanged();
 #else
    m_connectedToACProcess.terminate();
-   m_connectedToACProcess.start(PWR_CMD, QIODevice::ReadOnly);
+   m_connectedToACProcess.startCommand(PWR_CMD, QIODevice::ReadOnly);
 #endif
 
    QTimer::singleShot(1000, Qt::PreciseTimer, this, SLOT(updateConnectedToAC()));
@@ -386,6 +386,6 @@ QPair<quint64, quint64> Utilities::getCpuJiffies()
       file.close();
    }
 
-   return qMakePair(nonIdleJiffies, totalJiffies);
+   return QPair<quint64, quint64>(nonIdleJiffies, totalJiffies);
 }
 #endif


### PR DESCRIPTION
This commit ports QDriverStation from Qt 5 to Qt 6.10.0, enabling the application to run on modern Qt frameworks while maintaining compatibility with existing functionality.

## C++ API Changes

### QProcess API Migration
- Replace `QProcess::start(command, mode)` with `startCommand(command, mode)`
- Affects: src/utilities.cpp (3 occurrences)

### qMakePair API Migration
- Replace `qMakePair<T1,T2>(arg1, arg2)` with `QPair<T1,T2>(arg1, arg2)`
- Qt 6 requires rvalue references for qMakePair arguments
- Affects:
  - lib/LibDS/wrappers/Qt/EventLogger.cpp (13 occurrences)
  - src/utilities.cpp (1 occurrence)

## QML/QtQuick Migration

### QtQuick.Controls 1.x → 2.x
- Update all imports from `QtQuick.Controls 1.x` to `QtQuick.Controls 2.15`
- Controls 1.x was removed in Qt 6
- Affects: MainWindow.qml, Messages.qml, BatteryChart.qml, and others

### Control Styling System
- Migrate from Qt 5 style system (ComboBoxStyle, SpinBoxStyle) to Qt 6
- Use `background` and `contentItem` properties directly
- Complete rewrite of:
  - qml/Widgets/Spinbox.qml
  - qml/Widgets/Combobox.qml

### SpinBox Property Changes
- `minimumValue` → `from`
- `maximumValue` → `to`
- Applied across all QML files using SpinBox
- Fixed in Plot.qml, VoltageGraph.qml, Progressbar.qml

### SpinBox Editability
- Add `editable: true` to Spinbox widget to enable keyboard input
- Qt 6 SpinBox requires explicit editability flag for text entry

## Build Configuration
- Configured for x86_64 architecture on macOS (Rosetta compatibility)
- Compatible with pre-compiled SDL2 x86_64 library

## Testing
- Application launches successfully
- All controls respond to user input
- Runs stably under Rosetta on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)